### PR TITLE
feat(subscribe): Pass accept-language header through to basket.

### DIFF
--- a/lib/basket/fake.js
+++ b/lib/basket/fake.js
@@ -63,12 +63,27 @@ module.exports = function initApp() {
     var params = req.body;
     var email = params.email;
     var user = userData[email];
+    // Basket accepts either an explicit language choice,
+    // or an "accept_lang" preference string from which it
+    // will choose the best language.
+    var lang = params.lang;
+    if (! lang) {
+      lang = params.accept_lang;
+      if (lang) {
+        // We're just a test server, don't bother with any
+        // elaborate accept-lang parsing, just use first one.
+        lang = lang.split(/[\s\-;,]/)[0];
+      } else {
+        lang = '';
+      }
+    }
     var token;
     if (! user) {
       token = newToken();
       userData[email] = {
         email: email,
         token: token,
+        lang: lang,
         newsletters: params.newsletters.split(',')
       };
       tokenToUser[token] = userData[email];

--- a/lib/routes/subscribe.js
+++ b/lib/routes/subscribe.js
@@ -15,6 +15,9 @@ module.exports = function subscribe(req, res) {
 
   var params = req.body;
   params.email = res.locals.creds.email;
+  if (req.headers['accept-language']) {
+    params.accept_lang = req.headers['accept-language']; //eslint-disable-line camelcase
+  }
   logger.info('params', params);
 
   basket.request('/subscribe/', 'post', params)

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -107,4 +107,34 @@ describe('the /subscribe route', function () {
       .end(done);
   });
 
+  it('forwards the accept-language header if present', function (done) {
+    var EMAIL = 'test@example.com';
+    var NEWSLETTERS = 'a,b,c';
+    var ACCEPT_LANG = 'Accept-Language: de; q=1.0, en; q=0.5';
+    mocks.mockOAuthResponse().reply(200, {
+      email: EMAIL,
+      scope: 'basket:write'
+    });
+    mocks.mockBasketResponse().post('/subscribe/', function (body) {
+      /*eslint-disable camelcase */
+      assert.deepEqual(body, {
+        email: EMAIL,
+        newsletters: NEWSLETTERS,
+        accept_lang: ACCEPT_LANG
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok',
+    });
+    request(app)
+      .post('/subscribe')
+      .set('authorization', 'Bearer TOKEN')
+      .set('accept-language', ACCEPT_LANG)
+      .send({ newsletters: NEWSLETTERS })
+      .expect(200, {
+        status: 'ok',
+      })
+      .end(done);
+  });
+
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-content-server/issues/2676.  And is much easier to test than my previous attempt in https://github.com/mozilla/fxa-content-server/pull/3027.  @shane-tomlinson r?