### PR TITLE
feat(events): Add handling of SQS events for basket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To run the proxy:
 
   node ./bin/basket-proxy-server.js
 
+To process account-related events from SQS:
+
+  node ./bin/basket-event-handler.js
+
 For testing and development purposes, there's a minimal 'fake' implementation
 of the Basket server API that stores its state in memory.  Run it like so,
 and the proxy will use it unless configured with the URL of a live Basket

--- a/bin/basket-event-handler.js
+++ b/bin/basket-event-handler.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Runs an event-handling loop to process account-related events from SQS.
+ */
+
+var config = require('../lib/config');
+var events = require('../lib/events');
+var SQSReceiver = require('../lib/events/sqs');
+
+var basketQueue = new SQSReceiver(
+  config.get('basket.sqs.region'),
+  [config.get('basket.sqs.queue_url')]
+);
+basketQueue.on('data', events.handleEvent);
+basketQueue.start();

--- a/lib/basket/index.js
+++ b/lib/basket/index.js
@@ -13,19 +13,19 @@ var API_TIMEOUT = config.get('basket.api_timeout');
 
 
 // Send a request to the Basket backend
-module.exports.request = function basketRequest(path, method, params, done) {
-  var req = request({
+module.exports.request = function basketRequest(path, options, done) {
+  var reqOptions = {
     url: API_URL + path,
-    //strictSSL: true,
-    method: method,
+    strictSSL: true,
     timeout: API_TIMEOUT,
     headers: {
       'X-API-Key': API_KEY
-    },
-    form: params
-  }, done);
-
-  return req;
+    }
+  };
+  Object.keys(options).forEach(function (key) {
+    reqOptions[key] = options[key];
+  });
+  return request(reqOptions, done);
 };
 
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -49,6 +49,20 @@ var conf = module.exports = convict({
       doc: 'Timeout for talking to the Basket API server, in ms',
       format: 'duration',
       default: '5 seconds'
+    },
+    sqs: {
+      region: {
+        doc: 'The region where the queues live, e.g. us-east-1, us-west-2',
+        format: String,
+        env: 'BASKET_SQS_REGION',
+        default: ''
+      },
+      queue_url: {
+        doc: 'The basket event queue URL',
+        format: String,
+        env: 'BASKET_SQS_QUEUE_URL',
+        default: ''
+      }
     }
   },
   oauth_url: {

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+var basket = require('../basket');
+var logger = require('../logging')('events');
+
+var messageHandlers = {
+  verified: onVerified,
+  login: onLogin
+};
+
+
+module.exports.handleEvent = function handleEvent(message, cb) {
+  cb = cb || function () {};
+  logger.info('handleEvent', message);
+  var messageHandler = messageHandlers[message.event];
+  if (messageHandler) {
+    messageHandler(message, cb);
+  } else {
+    logger.info('handleEvent.ignored', message.event);
+    message.del(cb);
+  }
+};
+
+
+/* eslint-disable camelcase */
+
+// For each new verified account, register it with basket.
+function onVerified (message, cb) {
+  forwardEvent(message, '/fxa-register/', {
+    fxa_id: message.uid,
+    email: message.email,
+    // Basket won't accept empty or null `accept_lang` field,
+    // so we default to en-US.  This should only happen if
+    // the user has not sent an explicit Accept-Language header.
+    accept_lang: message.locale || 'en-US'
+  }, 'form', cb);
+}
+
+// For each new login, inform basket so it can build up a user model.
+function onLogin (message, cb) {
+  forwardEvent(message, '/fxa-activity/', {
+    activity: 'account.login',
+    service: message.service,
+    fxa_id: message.uid,
+    first_device: message.deviceCount === 1,
+    user_agent: message.userAgent
+  }, 'json', cb);
+}
+
+/* eslint-enable camelcase */
+
+function forwardEvent (message, endpoint, data, dataFormat, cb) {
+  // Ignore email addresses that are clearly from dev testing.
+  if (shouldIgnoreEmail(message.email)) {
+    message.del(cb);
+    return;
+  }
+
+  // Forward all others to basket API.
+  var options = { method: 'POST' };
+  options[dataFormat] = data;
+  basket.request(endpoint, options, function (err, res, body) {
+    message.endpoint = endpoint;
+
+    // Log network-level errors, and leave event in queue for retry.
+    if (err) {
+      message.err = err;
+      logger.error('forward-event.error.network', message);
+      return cb();
+    }
+
+    message.status = res.statusCode;
+    message.body = body;
+
+    // Log at error level for HTTP-level errors, info level otherwise.
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      logger.error('forward-event.error.http', message);
+    } else {
+      logger.info('forward-event', message);
+    }
+
+    message.del(cb);
+  });
+}
+
+
+function shouldIgnoreEmail (email) {
+  if (email.match(/@restmail.net$/)) {
+    return true;
+  }
+  if (email.match(/@restmail.lcip.org$/)) {
+    return true;
+  }
+  return false;
+}

--- a/lib/events/sqs.js
+++ b/lib/events/sqs.js
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var AWS = require('aws-sdk');
+var inherits = require('util').inherits;
+var EventEmitter = require('events').EventEmitter;
+
+var logger = require('../logging')('events.sqs');
+
+
+module.exports = SQSReceiver;
+
+function SQSReceiver(region, urls) {
+  this.sqs = new AWS.SQS({ region: region });
+  this.queueUrls = urls || [];
+  EventEmitter.call(this);
+}
+inherits(SQSReceiver, EventEmitter);
+
+
+SQSReceiver.prototype.start = function () {
+  for (var i = 0; i < this.queueUrls.length; i++) {
+    this.fetch(this.queueUrls[i]);
+  }
+};
+
+
+SQSReceiver.prototype.fetch = function (url) {
+  var errRetryTimer = null;
+  this.sqs.receiveMessage(
+    {
+      QueueUrl: url,
+      AttributeNames: [],
+      MaxNumberOfMessages: 10,
+      WaitTimeSeconds: 20
+    },
+    function (err, data) {
+      if (err) {
+        logger.error('fetch.receive-error', { url: url, err: err });
+        if (! errRetryTimer) {
+          // The aws lib will call the callback more than once with different errors.
+          // Avoid spawning multiple retries by using a timer.
+          // ಠ_ಠ
+          errRetryTimer = setTimeout(this.fetch.bind(this, url), 2000);
+        }
+        return;
+      }
+      function deleteMessage(message, cb) {
+        this.sqs.deleteMessage(
+          {
+            QueueUrl: url,
+            ReceiptHandle: message.ReceiptHandle
+          },
+          function checkDeleteError(err) {
+            if (err) {
+              logger.error('delete.error', { url: url, err: err });
+            }
+            if (cb) { cb(err); }
+          }
+        );
+      }
+      data.Messages = data.Messages || [];
+      for (var i = 0; i < data.Messages.length; i++) {
+        var msg = data.Messages[i];
+        var deleteFromQueue = deleteMessage.bind(this, msg);
+        try {
+          var body = JSON.parse(msg.Body);
+          var message = JSON.parse(body.Message);
+          message.del = deleteFromQueue;
+          this.emit('data', message);
+        }
+        catch (e) {
+          logger.error('fetch.dispatch-error', { url: url, err: e });
+          deleteFromQueue();
+        }
+      }
+      this.fetch(url);
+    }.bind(this)
+  );
+};

--- a/lib/routes/lookup.js
+++ b/lib/routes/lookup.js
@@ -14,10 +14,9 @@ module.exports = function lookup(req, res) {
     return;
   }
 
-  var params = req.body;
   var email = encodeURIComponent(res.locals.creds.email);
 
-  basket.request('/lookup-user/?email=' + email, 'get', params)
+  basket.request('/lookup-user/?email=' + email, { method: 'get' })
     .on('error', function (error) {
       logger.error('error', error);
       res.status(500).json(basket.errorResponse(error, basket.errors.UNKNOWN_ERROR));

--- a/lib/routes/subscribe.js
+++ b/lib/routes/subscribe.js
@@ -20,7 +20,7 @@ module.exports = function subscribe(req, res) {
   }
   logger.info('params', params);
 
-  basket.request('/subscribe/', 'post', params)
+  basket.request('/subscribe/', { method: 'post', form: params })
     .on('error', function (error) {
       logger.error('error', error);
       res.status(500).json(basket.errorResponse(error, basket.errors.UNKNOWN_ERROR));

--- a/lib/routes/unsubscribe.js
+++ b/lib/routes/unsubscribe.js
@@ -15,7 +15,7 @@ module.exports = function unsubscribe(req, res) {
   var creds = res.locals.creds;
   var email = encodeURIComponent(creds.email);
 
-  basket.request('/lookup-user/?email=' + email, 'get', {}, function (lookupError, httpRequest, body) {
+  basket.request('/lookup-user/?email=' + email, { method: 'get' }, function (lookupError, httpRequest, body) {
     if (lookupError) {
       logger.error('lookup-user.error', lookupError);
       res.status(400).json(basket.errorResponse(lookupError, basket.errors.UNKNOWN_ERROR));
@@ -40,7 +40,7 @@ module.exports = function unsubscribe(req, res) {
     params.email = creds.email;
     logger.info('params', params);
 
-    basket.request('/unsubscribe/' + responseData.token + '/', 'post', params)
+    basket.request('/unsubscribe/' + responseData.token + '/', { method: 'post', form: params })
       .on('error', function (error) {
         logger.error('error', error);
         res.status(500).json(basket.errorResponse(error, basket.errors.UNKNOWN_ERROR));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,28 @@
   "name": "fxa-basket-proxy",
   "version": "0.44.0",
   "dependencies": {
+    "aws-sdk": {
+      "version": "2.2.6",
+      "from": "aws-sdk@2.2.6",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.6.tgz",
+      "dependencies": {
+        "sax": {
+          "version": "0.5.3",
+          "from": "sax@0.5.3",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
+        },
+        "xml2js": {
+          "version": "0.2.8",
+          "from": "xml2js@0.2.8",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
+        },
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
     "blanket": {
       "version": "1.1.7",
       "from": "blanket@1.1.7",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",
   "dependencies": {
+    "aws-sdk": "2.2.6",
     "bluebird": "2.9.34",
     "body-parser": "1.13.3",
     "convict": "1.0.0",

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* eslint-disable camelcase */
+
+var assert = require('assert');
+
+var events = require('../lib/events');
+
+var mocks = require('./lib/mocks');
+
+
+var UID = 'foobar';
+var EMAIL = 'foobar@example.com';
+var LOCALE = 'en-AU';
+var USER_AGENT = 'a fake testing browser (like Gecko)';
+var SERVICE = 'sync';
+
+
+describe('the handleEvent() function', function () {
+
+  it('calls /fxa-register for account verification events', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
+    }).post('/fxa-register/', function (body) {
+      assert.deepEqual(body, {
+        fxa_id: UID,
+        email: EMAIL,
+        accept_lang: LOCALE
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok'
+    });
+    events.handleEvent({
+      event: 'verified',
+      uid: UID,
+      email: EMAIL,
+      locale: LOCALE,
+      del: function () {
+        done();
+      }
+    });
+  });
+
+  it('calls /fxa-activity for device login events', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/json' }
+    }).post('/fxa-activity/', function (body) {
+      assert.deepEqual(body, {
+        activity: 'account.login',
+        service: SERVICE,
+        fxa_id: UID,
+        first_device: true,
+        user_agent: USER_AGENT
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok'
+    });
+    events.handleEvent({
+      event: 'login',
+      service: SERVICE,
+      uid: UID,
+      email: EMAIL,
+      deviceCount: 1,
+      userAgent: USER_AGENT,
+      del: function () {
+        done();
+      }
+    });
+  });
+
+  it('calls /fxa-activity with a correct `first_device` value', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/json' }
+    }).post('/fxa-activity/', function (body) {
+      assert.deepEqual(body, {
+        activity: 'account.login',
+        service: SERVICE,
+        fxa_id: UID,
+        first_device: false,
+        user_agent: USER_AGENT
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok'
+    });
+    events.handleEvent({
+      event: 'login',
+      service: SERVICE,
+      uid: UID,
+      email: EMAIL,
+      deviceCount: 2,
+      userAgent: USER_AGENT,
+      del: function () {
+        done();
+      }
+    });
+  });
+
+  it('ignores unrecognized event types', function (done) {
+    events.handleEvent({
+      event: 'unknownEvent',
+      del: function () {
+        // This is reached without trying to hit the basket server.
+        done();
+      }
+    });
+  });
+
+  it('ignores "verified" events from dev email addresses', function (done) {
+    events.handleEvent({
+      event: 'verified',
+      uid: UID,
+      email: 'foo@restmail.net',
+      locale: LOCALE,
+      del: function () {
+        // This is reached without trying to hit the basket server.
+        done();
+      }
+    });
+  });
+
+  it('ignores "login" events from dev email addresses', function (done) {
+    events.handleEvent({
+      event: 'login',
+      service: SERVICE,
+      uid: UID,
+      email: 'bar@restmail.lcip.org',
+      deviceCount: 1,
+      userAgent: USER_AGENT,
+      del: function () {
+        // This is reached without trying to hit the basket server.
+        done();
+      }
+    });
+  });
+
+  it('uses "en-US" as the default locale is none is provided', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
+    }).post('/fxa-register/', function (body) {
+      assert.deepEqual(body, {
+        fxa_id: UID,
+        email: EMAIL,
+        accept_lang: 'en-US'
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok'
+    });
+    events.handleEvent({
+      event: 'verified',
+      uid: UID,
+      email: EMAIL,
+      del: function () {
+        done();
+      }
+    });
+  });
+
+  it('does not delete events if a network-level error occurs', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
+    }).post('/fxa-register/', function (body) {
+      assert.deepEqual(body, {
+        fxa_id: UID,
+        email: EMAIL,
+        accept_lang: LOCALE
+      });
+      return true;
+    }).replyWithError('ruh-roh!');
+    events.handleEvent({
+      event: 'verified',
+      uid: UID,
+      email: EMAIL,
+      locale: LOCALE,
+      del: function () {
+        assert.fail('should not delete the message from the queue');
+      }
+    }, done);
+  });
+
+  it('does delete events if a HTTP-level error occurs', function (done) {
+    mocks.mockBasketResponse({
+      reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
+    }).post('/fxa-register/', function (body) {
+      assert.deepEqual(body, {
+        fxa_id: UID,
+        email: EMAIL,
+        accept_lang: LOCALE
+      });
+      return true;
+    }).reply(500, {
+      status: 'error',
+      code: 99,
+      desc: 'Error: ruh-roh!'
+    });
+    events.handleEvent({
+      event: 'verified',
+      uid: UID,
+      email: EMAIL,
+      locale: LOCALE,
+      del: function () {
+        done();
+      }
+    });
+  });
+
+});

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -15,10 +15,9 @@ module.exports.mockOAuthResponse = function mockOAuthResponse() {
   return nock(VERIFY_URL).post('');
 };
 
-module.exports.mockBasketResponse = function mockBasketResponse() {
-  return nock(API_URL, {
-    reqheaders: {
-      'x-api-key': API_KEY
-    }
-  });
+module.exports.mockBasketResponse = function mockBasketResponse(opts) {
+  opts = opts || {};
+  opts.reqheaders = opts.reqheaders || {};
+  opts.reqheaders['x-api-key'] = API_KEY;
+  return nock(API_URL, opts);
 };


### PR DESCRIPTION
This moves our existing SQS-event-handling logic out of fxa-auth-server
and into the fxa-basket-proxy repo, where we can maintain it alongside
the other basket-related code.

It's a copy, cleanup and mild refactor of these files:

  https://github.com/mozilla/fxa-auth-server/blob/master/bin/basket.js
  https://github.com/mozilla/fxa-auth-server/blob/master/lib/sqs.js

@philbooth since a lot of the work in those files was yours, can you please r? this one.