### PR TITLE
feat(metrics): add activity events for subscribe/unsubscribe

### DIFF
--- a/lib/routes/subscribe.js
+++ b/lib/routes/subscribe.js
@@ -19,6 +19,11 @@ module.exports = function subscribe(req, res) {
     params.accept_lang = req.headers['accept-language']; //eslint-disable-line camelcase
   }
   logger.info('params', params);
+  logger.info('activityEvent', {
+    event: 'basket.subscribe',
+    uid: res.locals.creds.user,
+    userAgent: req.headers['user-agent'] || undefined,
+  });
 
   basket.request('/subscribe/', { method: 'post', form: params })
     .on('error', function (error) {

--- a/lib/routes/unsubscribe.js
+++ b/lib/routes/unsubscribe.js
@@ -15,6 +15,12 @@ module.exports = function unsubscribe(req, res) {
   var creds = res.locals.creds;
   var email = encodeURIComponent(creds.email);
 
+  logger.info('activityEvent', {
+    event: 'basket.unsubscribe',
+    uid: res.locals.creds.user,
+    userAgent: req.headers['user-agent'] || undefined,
+  });
+
   basket.request('/lookup-user/?email=' + email, { method: 'get' }, function (lookupError, httpRequest, body) {
     if (lookupError) {
       logger.error('lookup-user.error', lookupError);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -51,6 +51,12 @@ module.exports = function verifyOAuthToken() {
         return;
       }
 
+      if (! body.user) {
+        logger.error('auth.missing-user', body);
+        res.status(400).json(basket.errorResponse('missing user', basket.errors.AUTH_ERROR));
+        return;
+      }
+
       if (! body.email) {
         logger.error('auth.missing-email', body);
         res.status(400).json(basket.errorResponse('missing email', basket.errors.AUTH_ERROR));

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -9,6 +9,9 @@ var app = require('../lib/app')();
 var mocks = require('./lib/mocks');
 
 
+var UID = 'abcdef123456';
+
+
 describe('the route /lookup-user', function () {
 
   it('forwards properly-authenticated requests through to basket', function (done) {
@@ -16,6 +19,7 @@ describe('the route /lookup-user', function () {
     var TOKEN = 'abcdef123456';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -40,6 +44,7 @@ describe('the route /lookup-user', function () {
   it('returns an error if the basket server request errors out', function (done) {
     var EMAIL = 'test@example.com';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -100,7 +105,7 @@ describe('the route /lookup-user', function () {
 
   it('returns an error if the oauth token has no associated email', function (done) {
     mocks.mockOAuthResponse().reply(200, {
-      uid: 'abcdef'
+      user: UID,
     });
     request(app)
       .get('/lookup-user')
@@ -117,6 +122,7 @@ describe('the route /lookup-user', function () {
   it('returns an error if the oauth token has incorrect scope', function (done) {
     var EMAIL = 'test@example.com';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'profile'
     });

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -9,6 +9,8 @@ var app = require('../lib/app')();
 
 var mocks = require('./lib/mocks');
 
+var UID = 'abcdef123456';
+
 
 describe('the /subscribe route', function () {
 
@@ -16,6 +18,7 @@ describe('the /subscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -42,6 +45,7 @@ describe('the /subscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -85,6 +89,7 @@ describe('the /subscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -112,6 +117,7 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     var ACCEPT_LANG = 'Accept-Language: de; q=1.0, en; q=0.5';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });

--- a/test/unsubscribe.js
+++ b/test/unsubscribe.js
@@ -9,6 +9,7 @@ var app = require('../lib/app')();
 
 var mocks = require('./lib/mocks');
 
+var UID = 'abcdef123456';
 
 describe('the /unsubscribe route', function () {
 
@@ -17,6 +18,7 @@ describe('the /unsubscribe route', function () {
     var TOKEN = 'abcdef123456';
     var NEWSLETTERS = 'a';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -48,6 +50,7 @@ describe('the /unsubscribe route', function () {
     var TOKEN = 'abcdef123456';
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -83,6 +86,7 @@ describe('the /unsubscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'c,d';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -121,6 +125,7 @@ describe('the /unsubscribe route', function () {
     var TOKEN = 'abcdef123456';
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -152,6 +157,7 @@ describe('the /unsubscribe route', function () {
     var TOKEN = 'abcdef123456';
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -184,6 +190,7 @@ describe('the /unsubscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });
@@ -205,6 +212,7 @@ describe('the /unsubscribe route', function () {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
+      user: UID,
       email: EMAIL,
       scope: 'basket:write'
     });


### PR DESCRIPTION
Fixes #9.  @vladikoff r?

(I realised I'm yet to cut a train-47 tag for fxa-basket-proxy, and this change seems pretty small, so we could potential bundle it with an earlier deploy to start the metrics flowing)