### PR TITLE
feat(email): explicitly fetch email address from profile data

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -65,6 +65,12 @@ var conf = module.exports = convict({
       }
     }
   },
+  fxaccount_url: {
+    default: 'http://127.0.0.1:9000',
+    doc: 'The url of the Firefox Account auth server',
+    env: 'FXA_URL',
+    format: 'url'
+  },
   oauth_url: {
     doc: 'The url of the Firefox Account OAuth server',
     format: 'url',

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -9,10 +9,15 @@ var config = require('../../lib/config');
 var API_KEY = config.get('basket.api_key');
 var API_URL = config.get('basket.api_url');
 var VERIFY_URL = config.get('oauth_url') + '/v1/verify';
+var PROFILE_URL = config.get('fxaccount_url') + '/v1/account/profile';
 
 
 module.exports.mockOAuthResponse = function mockOAuthResponse() {
   return nock(VERIFY_URL).post('');
+};
+
+module.exports.mockProfileResponse = function mockOAuthResponse() {
+  return nock(PROFILE_URL).get('');
 };
 
 module.exports.mockBasketResponse = function mockBasketResponse(opts) {

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -19,8 +19,10 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().post('/subscribe/', function (body) {
       assert.deepEqual(body, {
@@ -46,8 +48,10 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().post('/subscribe/', function (body) {
       assert.deepEqual(body, {
@@ -90,8 +94,10 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().post('/subscribe/', function (body) {
       assert.deepEqual(body, {
@@ -118,8 +124,10 @@ describe('the /subscribe route', function () {
     var ACCEPT_LANG = 'Accept-Language: de; q=1.0, en; q=0.5';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().post('/subscribe/', function (body) {
       /*eslint-disable camelcase */

--- a/test/unsubscribe.js
+++ b/test/unsubscribe.js
@@ -19,8 +19,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'a';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(200, {
       status: 'ok',
@@ -51,8 +53,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(200, {
       status: 'ok',
@@ -87,8 +91,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'c,d';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(404, {
       status: 'error',
@@ -126,8 +132,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(200, {
       status: 'ok',
@@ -158,8 +166,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(200, {
       status: 'ok',
@@ -191,8 +201,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL})
       .replyWithError('ruh-roh!');
@@ -213,8 +225,10 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      email: EMAIL,
       scope: 'basket:write'
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
     });
     mocks.mockBasketResponse().get('/lookup-user/').query({email: EMAIL}).reply(200, '<html>eh?</html>');
     request(app)


### PR DESCRIPTION
We're deprecating the oauth server's ability to return an email address when verifying an oauth token [1].  Reliers should instead fetch it explicitly from the profile data.  This fixes basket-proxy to do so, pulling it direct from the auth-server since it's the only piece of profile data that we need.

@seanmonstar r?

(The config naming convention mirrors the option used in fxa-content-server, since this shares a config file with it in production)

[1] https://github.com/mozilla/fxa-oauth-server/issues/352#issuecomment-155357519