### PR TITLE
feat(events): Simplify logic for utm_campaign auto-subscription.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,11 +50,14 @@ var conf = module.exports = convict({
       format: 'duration',
       default: '5 seconds'
     },
-    newsletter_campaign_ids: {
+    newsletter_campaigns: {
       doc: 'Values of utm_campaign that identify a newsletter campaign',
-      format: Array,
-      default: ['test-newsletter-campaign'],
-      env: 'BASKET_NEWSLETTER_CAMPAIGN_IDS'
+      format: Object,
+      default: {
+        'fxa-embedded-form-moz': 'mozilla-welcome',
+        'fxa-embedded-form-fx': 'firefox-welcome'
+      },
+      env: 'BASKET_NEWSLETTER_CAMPAIGNS'
     },
     source_url: {
       doc: 'The source_url value to report to basket in subscription requests',

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -12,11 +12,7 @@ var config = require('../config');
 // Certain special values of the utm_campaign metrics parameters
 // are used to indicate a newsletter campaign, and cause us to
 // auto-subscribe the user to a particular newsletter.
-var NEWSLETTER_CAMPAIGN_IDS = config.get('basket.newsletter_campaign_ids')
-  .reduce(function (setOfIds, id) {
-    setOfIds[id] = true;
-    return setOfIds;
-  }, {});
+var NEWSLETTER_CAMPAIGNS = config.get('basket.newsletter_campaigns');
 
 var SOURCE_URL_BASE = config.get('basket.source_url');
 
@@ -60,9 +56,9 @@ function onLogin (message, cb) {
   var metrics = message.metricsContext || {};
   return Promise.resolve().then(function () {
     // If utm_campaign indicates it's a newsletter campaign, flag it by
-    // subscribing to the newsletter identified in utm_content.
-    if (metrics.utm_campaign in NEWSLETTER_CAMPAIGN_IDS) {
-      var newsletter = metrics.utm_content;
+    // subscribing to the corresponding newsletter.
+    var newsletter = NEWSLETTER_CAMPAIGNS[metrics.utm_campaign];
+    if (metrics.utm_campaign && newsletter) {
       var source_url = url.parse(SOURCE_URL_BASE, true);
       for (var key in metrics) {
         if (key.indexOf('utm_') === 0) {

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -52,7 +52,7 @@ function onVerified (message) {
 }
 
 // For each new login, inform basket so it can build up a user model.
-function onLogin (message, cb) {
+function onLogin (message) {
   var metrics = message.metricsContext || {};
   return Promise.resolve().then(function () {
     // If utm_campaign indicates it's a newsletter campaign, flag it by

--- a/test/events.js
+++ b/test/events.js
@@ -17,6 +17,13 @@ var LOCALE = 'en-AU';
 var USER_AGENT = 'a fake testing browser (like Gecko)';
 var SERVICE = 'sync';
 
+var CAMPAIGN_NEWSLETTER_SLUG = 'mozilla-welcome';
+var CAMPAIGN_NEWSLETTER_CONTEXT = {
+  utm_campaign: 'fxa-embedded-form-moz',
+  utm_source: 'firstrun'
+};
+var CAMPAIGN_NEWSLETTER_SOURCE_URL = 'https://accounts.firefox.com/?utm_campaign=fxa-embedded-form-moz&utm_source=firstrun';
+
 
 describe('the handleEvent() function', function () {
 
@@ -251,14 +258,11 @@ describe('the handleEvent() function', function () {
   });
 
   it('subscribes to newsletters when given specific utm params', function (done) {
-    var EMAIL = 'test@example.com';
-    var NEWSLETTER = 'campaign1';
-    var SOURCE_URL = 'https://accounts.firefox.com/?utm_campaign=test-newsletter-campaign&utm_source=firstrun&utm_content=campaign1';
     mocks.mockBasketResponse().post('/subscribe/', function (body) {
       assert.deepEqual(body, {
         email: EMAIL,
-        newsletters: NEWSLETTER,
-        source_url: SOURCE_URL
+        newsletters: CAMPAIGN_NEWSLETTER_SLUG,
+        source_url: CAMPAIGN_NEWSLETTER_SOURCE_URL
       });
       return true;
     }).reply(200, {
@@ -273,11 +277,7 @@ describe('the handleEvent() function', function () {
         fxa_id: UID,
         first_device: false,
         user_agent: USER_AGENT,
-        metrics_context: {
-          utm_campaign: 'test-newsletter-campaign',
-          utm_source: 'firstrun',
-          utm_content: NEWSLETTER
-        }
+        metrics_context: CAMPAIGN_NEWSLETTER_CONTEXT
       });
       return true;
     }).reply(200, {
@@ -290,11 +290,7 @@ describe('the handleEvent() function', function () {
       email: EMAIL,
       deviceCount: 2,
       userAgent: USER_AGENT,
-      metricsContext: {
-        utm_campaign: 'test-newsletter-campaign',
-        utm_source: 'firstrun',
-        utm_content: NEWSLETTER
-      },
+      metricsContext: CAMPAIGN_NEWSLETTER_CONTEXT,
       del: function () {
         done();
       }
@@ -302,16 +298,13 @@ describe('the handleEvent() function', function () {
   });
 
   it('does not delete events on network-level error in campaign subscription', function (done) {
-    var EMAIL = 'test@example.com';
-    var NEWSLETTER = 'campaign1';
-    var SOURCE_URL = 'https://accounts.firefox.com/?utm_campaign=test-newsletter-campaign&utm_source=firstrun&utm_content=campaign1';
     mocks.mockBasketResponse({
       reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
     }).post('/subscribe/', function (body) {
       assert.deepEqual(body, {
         email: EMAIL,
-        newsletters: NEWSLETTER,
-        source_url: SOURCE_URL
+        newsletters: CAMPAIGN_NEWSLETTER_SLUG,
+        source_url: CAMPAIGN_NEWSLETTER_SOURCE_URL
       });
       return true;
     }).replyWithError('ruh-roh!');
@@ -322,11 +315,7 @@ describe('the handleEvent() function', function () {
       email: EMAIL,
       deviceCount: 2,
       userAgent: USER_AGENT,
-      metricsContext: {
-        utm_campaign: 'test-newsletter-campaign',
-        utm_source: 'firstrun',
-        utm_content: NEWSLETTER
-      },
+      metricsContext: CAMPAIGN_NEWSLETTER_CONTEXT,
       del: function () {
         assert.fail('should not delete the message from the queue');
       }
@@ -337,16 +326,13 @@ describe('the handleEvent() function', function () {
   });
 
   it('does delete events on HTTP-level error in campaign subscription', function (done) {
-    var EMAIL = 'test@example.com';
-    var NEWSLETTER = 'campaign1';
-    var SOURCE_URL = 'https://accounts.firefox.com/?utm_campaign=test-newsletter-campaign&utm_source=firstrun&utm_content=campaign1';
     mocks.mockBasketResponse({
       reqheaders: { 'content-type': 'application/x-www-form-urlencoded' }
     }).post('/subscribe/', function (body) {
       assert.deepEqual(body, {
         email: EMAIL,
-        newsletters: NEWSLETTER,
-        source_url: SOURCE_URL
+        newsletters: CAMPAIGN_NEWSLETTER_SLUG,
+        source_url: CAMPAIGN_NEWSLETTER_SOURCE_URL
       });
       return true;
     }).reply(500, {
@@ -363,11 +349,7 @@ describe('the handleEvent() function', function () {
         fxa_id: UID,
         first_device: false,
         user_agent: USER_AGENT,
-        metrics_context: {
-          utm_campaign: 'test-newsletter-campaign',
-          utm_source: 'firstrun',
-          utm_content: NEWSLETTER
-        }
+        metrics_context: CAMPAIGN_NEWSLETTER_CONTEXT
       });
       return true;
     }).reply(200, {
@@ -380,11 +362,7 @@ describe('the handleEvent() function', function () {
       email: EMAIL,
       deviceCount: 2,
       userAgent: USER_AGENT,
-      metricsContext: {
-        utm_campaign: 'test-newsletter-campaign',
-        utm_source: 'firstrun',
-        utm_content: NEWSLETTER
-      },
+      metricsContext: CAMPAIGN_NEWSLETTER_CONTEXT,
       del: function () {
         done();
       }


### PR DESCRIPTION
In testing the work from #27 with the marketing team, we found that having to use a combination of `utm_campaign` and `utm_content` to trigger the newsletter optin was not ideal.  We agreed to simplify the interface by triggering only off the `utm_campaign` parameter, with a fixed set of known campaign values mapping to a fixed set of known subscriptions.

@vladikoff could you please give this an r?

Connects to https://github.com/mozilla/fxa/issues/148