### PR TITLE
fix(version): use cwd and env var to get version

### DIFF
--- a/lib/routes/version.js
+++ b/lib/routes/version.js
@@ -15,7 +15,6 @@
  */
 
 var cp = require('child_process');
-var util = require('util');
 var path = require('path');
 var Promise = require('bluebird');
 var logger = require('../logging')('routes.version');
@@ -40,8 +39,7 @@ function getCommitHash () {
   var deferred = Promise.defer();
 
   var gitDir = path.resolve(__dirname, '..', '..', '.git');
-  var cmd = util.format('git --git-dir=%s rev-parse HEAD', gitDir);
-  cp.exec(cmd, function (err, stdout) {
+  cp.exec('git rev-parse HEAD', { cwd: gitDir }, function (err, stdout) {
     if (err) {
       // ignore the error
       deferred.resolve(UNKNOWN);
@@ -67,8 +65,8 @@ function getSourceRepo () {
 
   var gitDir = path.resolve(__dirname, '..', '..', '.git');
   var configPath = path.join(gitDir, 'config');
-  var cmd = util.format('git config --file %s --get remote.origin.url', configPath);
-  cp.exec(cmd, function (err, stdout) {
+  var cmd = 'git config --get remote.origin.url';
+  cp.exec(cmd, { env: { GIT_CONFIG: configPath } }, function (err, stdout) {
     if (err) {
       // ignore the error
       deferred.resolve(UNKNOWN);


### PR DESCRIPTION
refs: bug 1320217
similar to: mozilla/fxa-content-server#4804

Fix command execution in the unlikely event the application is run from a location with a malicious or malformed directory name per rfk's suggestions in the bug mentioned above.

Functional Tests:

- [x] run from a malicious path on master executes path command:

```
fxa-local-dev/fxa-basket-proxy - [master] » curl -X GET http://localhost:1114/__version__
{
  "version": "0.73.0",
  "commit": "usage: git [--version] [--help] [-C <path>] [-c name=value]\n           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n           [-p | --paginate | --no-pager] [--no-replace-objects] [--bare]\n           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]\n           <command> [<args>]\n\nThese are common Git commands used in various situations:\n\nstart a working area (see also: git help tutorial)\n   clone      Clone a repository into a new directory\n   init       Create an empty Git repository or reinitialize an existing one\n\nwork on the current change (see also: git help everyday)\n   add        Add file contents to the index\n   mv         Move or rename a file, a directory, or a symlink\n   reset      Reset current HEAD to the specified state\n   rm         Remove files from the working tree and from the index\n\nexamine the history and state (see also: git help revisions)\n   bisect     Use binary search to find the commit that introduced a bug\n   grep       Print lines matching a pattern\n   log        Show commit logs\n   show       Show various types of objects\n   status     Show the working tree status\n\ngrow, mark and tweak your common history\n   branch     List, create, or delete branches\n   checkout   Switch branches or restore working tree files\n   commit     Record changes to the repository\n   diff       Show changes between commits, commit and working tree, etc\n   merge      Join two or more development histories together\n   rebase     Reapply commits on top of another base tip\n   tag        Create, list, delete or verify a tag object signed with GPG\n\ncollaborate (see also: git help workflows)\n   fetch      Download objects and refs from another repository\n   pull       Fetch from and integrate with another repository or a local branch\n   push       Update remote refs along with associated objects\n\n'git help -a' and 'git help -g' list available subcommands and some\nconcept guides. See 'git help <command>' or 'git help <concept>'\nto read about a specific subcommand or concept.\nhi",
  "source": "hi"
}
```

- [x] run from a malicious path on this branch does not execute path command:

```
fxa-local-dev/fxa-basket-proxy - [fix-version] » curl -X GET http://localhost:1114/__version__
{
  "version": "0.73.0",
  "commit": "c650ee7e8baf0854eada0d08264ee4cd68a83f08",
  "source": "https://github.com/mozilla/fxa-basket-proxy.git"
}
```