### PR TITLE
feat(sqs): look for `marketingOptIn` on 'verified' events

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -63,6 +63,12 @@ var conf = module.exports = convict({
       },
       env: 'BASKET_NEWSLETTER_CAMPAIGNS'
     },
+    newsletter_id_register: {
+      doc: 'Newsletter ID to subscribe new registrations who opted in.',
+      format: String,
+      default: 'firefox-accounts-journey',
+      env: 'BASKET_NEWSLETTER_ID_REGISTER'
+    },
     source_url: {
       doc: 'The source_url value to report to basket in subscription requests',
       format: String,

--- a/test/unsubscribe.js
+++ b/test/unsubscribe.js
@@ -223,6 +223,12 @@ describe('the /unsubscribe route', function () {
   it('returns an error if the token lookup request returns invalid JSON', function (done) {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
+    var desc;
+    try {
+      JSON.parse('<');
+    } catch (ex) {
+      desc = String(ex);
+    }
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
       scope: 'basket:write'
@@ -235,14 +241,12 @@ describe('the /unsubscribe route', function () {
       .post('/unsubscribe')
       .set('authorization', 'Bearer TOKEN')
       .send({ newsletters: NEWSLETTERS })
-      .end(function (err, res) {
-        var body = res.body;
-        assert.equal(res.status, 400);
-        assert.equal(body.status, 'error');
-        assert.equal(body.code, '99');
-        assert.ok(/^SyntaxError:/.test(body.desc));
-        done();
-      });
+      .expect(400, {
+        status: 'error',
+        code: 99,
+        desc: desc
+      })
+      .end(done);
   });
 
 });


### PR DESCRIPTION
The auth-server will start telling us when a verified account opted in
to marketing. We can look for in the SQS messages.

Closes #40