### PR TITLE
fix(api): More closely match native basket api behaviour.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -17,6 +17,7 @@ module.exports = function initApp() {
   var app = express();
   app.set('x-powered-by', false);
   app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded());
   app.use(logSummary());
   app.use(cors({
     origin: CORS_ORIGIN

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -3,15 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 
-var request = require('request');
+const request = require('request');
 
-var config = require('./config');
-var logger = require('./logging')('verify');
-var basket = require('./basket');
+const config = require('./config');
+const logger = require('./logging')('verify');
+const basket = require('./basket');
 
-var VERIFY_URL = config.get('oauth_url') + '/v1/verify';
-var PROFILE_URL = config.get('fxaccount_url') + '/v1/account/profile';
-var REQUIRED_SCOPE = 'basket:write';
+const VERIFY_URL = config.get('oauth_url') + '/v1/verify';
+const PROFILE_URL = config.get('fxaccount_url') + '/v1/account/profile';
+const REQUIRED_SCOPE_REGEX = /^basket(:write)?$/;
 
 // Adds FxA OAuth token verification to an express app.
 
@@ -58,7 +58,7 @@ module.exports = function verifyOAuthToken() {
         return;
       }
 
-      if (body.scope.indexOf(REQUIRED_SCOPE) === -1) {
+      if (! body.scope.find(s => REQUIRED_SCOPE_REGEX.test(s))) {
         logger.error('auth.invalid-scope', body);
         res.status(400).json(basket.errorResponse('invalid scope', basket.errors.AUTH_ERROR));
         return;

--- a/test/sms.js
+++ b/test/sms.js
@@ -19,7 +19,7 @@ describe('/sms', function () {
     var OPTIN = 'N';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket:write']
     });
     mocks.mockProfileResponse().reply(200, {
       email: 'dont@ca.re',
@@ -70,7 +70,7 @@ describe('/sms', function () {
     var OPTIN = 'N';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket:write']
     });
     mocks.mockProfileResponse().reply(200, {
       email: 'dont@ca.re',

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -21,7 +21,7 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -47,12 +47,44 @@ describe('the /subscribe route', function () {
       .end(done);
   });
 
+  it('accepts form-encoded request bodies', function (done) {
+    var EMAIL = 'test@example.com';
+    var NEWSLETTERS = 'a,b,c';
+    mocks.mockOAuthResponse().reply(200, {
+      user: UID,
+      scope: ['basket']
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
+    });
+    mocks.mockBasketResponse().post('/subscribe/', function (body) {
+      /*eslint-disable camelcase */
+      assert.deepEqual(body, {
+        email: EMAIL,
+        newsletters: NEWSLETTERS,
+        source_url: DEFAULT_SOURCE_URL
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok',
+    });
+    request(app)
+      .post('/subscribe')
+      .set('authorization', 'Bearer TOKEN')
+      .type('form')
+      .send({ newsletters: NEWSLETTERS })
+      .expect(200, {
+        status: 'ok',
+      })
+      .end(done);
+  });
+
   it('passes through all params from body, except email', function (done) {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -100,7 +132,7 @@ describe('the /subscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -132,7 +164,7 @@ describe('the /subscribe route', function () {
     var ACCEPT_LANG = 'Accept-Language: de; q=1.0, en; q=0.5';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -166,7 +198,7 @@ describe('the /subscribe route', function () {
     var SOURCE_URL = 'https://secure.example.com';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,

--- a/test/unsubscribe.js
+++ b/test/unsubscribe.js
@@ -19,7 +19,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'a';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -53,7 +53,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -91,7 +91,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'c,d';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -132,7 +132,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -166,7 +166,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'b';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -201,7 +201,7 @@ describe('the /unsubscribe route', function () {
     var NEWSLETTERS = 'a,b,c';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,
@@ -231,7 +231,7 @@ describe('the /unsubscribe route', function () {
     }
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: 'basket:write'
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: EMAIL,


### PR DESCRIPTION
The basket API natively accepts the OAuth scope "basket", and expects request bodies to be form-urlencoded.  This commit updates basket-proxy to accept both those things, while keeping backwards compatibility with previous behaviour.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1417298#c6 and related discussion.  @shane-tomlinson r?