### PR TITLE
chore(api): More tests and cleanups for basket API compatibility.

### DIFF
--- a/lib/verify.js
+++ b/lib/verify.js
@@ -58,6 +58,12 @@ module.exports = function verifyOAuthToken() {
         return;
       }
 
+      if (! body.scope || ! (body.scope instanceof Array)) {
+        logger.error('auth.missing-scope', body);
+        res.status(400).json(basket.errorResponse('missing scope', basket.errors.AUTH_ERROR));
+        return;
+      }
+
       if (! body.scope.find(s => REQUIRED_SCOPE_REGEX.test(s))) {
         logger.error('auth.invalid-scope', body);
         res.status(400).json(basket.errorResponse('invalid scope', basket.errors.AUTH_ERROR));

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -153,7 +153,7 @@ describe('the route /lookup-user', function () {
       .end(done);
   });
 
-  it('returns an error if the oauth token has several incorrect scopes', function (done) {
+  it('returns an error if the oauth token has several scopes, but none match', function (done) {
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
       scope: ['profile', 'basketto', 'basket:writer']
@@ -204,7 +204,7 @@ describe('the route /lookup-user', function () {
 
   it('returns an error if the oauth response has no userid', function (done) {
     mocks.mockOAuthResponse().reply(200, {
-      scope: 'basket:write profile:email'
+      scope: ['basket', 'profile:email']
     });
     request(app)
       .get('/lookup-user')
@@ -218,10 +218,43 @@ describe('the route /lookup-user', function () {
       .end(done);
   });
 
+  it('returns an error if the oauth response has no scope', function (done) {
+    mocks.mockOAuthResponse().reply(200, {
+      user: UID,
+    });
+    request(app)
+      .get('/lookup-user')
+      .set('authorization', 'Bearer TOKEN')
+      .expect('Content-Type', /json/)
+      .expect(400, {
+        status: 'error',
+        code: 7,
+        desc: 'missing scope'
+      })
+      .end(done);
+  });
+
+  it('returns an error if the oauth response has non-array scope', function (done) {
+    mocks.mockOAuthResponse().reply(200, {
+      user: UID,
+      scope: 'basket profile:email'
+    });
+    request(app)
+      .get('/lookup-user')
+      .set('authorization', 'Bearer TOKEN')
+      .expect('Content-Type', /json/)
+      .expect(400, {
+        status: 'error',
+        code: 7,
+        desc: 'missing scope'
+      })
+      .end(done);
+  });
+
   it('returns an error if the auth server profile has no associated email', function (done) {
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: ['basket:write', 'profile:locale']
+      scope: ['basket', 'profile:locale']
     });
     mocks.mockProfileResponse().reply(200, {
       locale: 'en-AU'

--- a/test/sms.js
+++ b/test/sms.js
@@ -19,7 +19,7 @@ describe('/sms', function () {
     var OPTIN = 'N';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: ['basket:write']
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: 'dont@ca.re',
@@ -70,7 +70,7 @@ describe('/sms', function () {
     var OPTIN = 'N';
     mocks.mockOAuthResponse().reply(200, {
       user: UID,
-      scope: ['basket:write']
+      scope: ['basket']
     });
     mocks.mockProfileResponse().reply(200, {
       email: 'dont@ca.re',

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -79,6 +79,37 @@ describe('the /subscribe route', function () {
       .end(done);
   });
 
+  it('accepts a trailing slash on the path', function (done) {
+    var EMAIL = 'test@example.com';
+    var NEWSLETTERS = 'a,b,c';
+    mocks.mockOAuthResponse().reply(200, {
+      user: UID,
+      scope: ['basket']
+    });
+    mocks.mockProfileResponse().reply(200, {
+      email: EMAIL,
+    });
+    mocks.mockBasketResponse().post('/subscribe/', function (body) {
+      /*eslint-disable camelcase */
+      assert.deepEqual(body, {
+        email: EMAIL,
+        newsletters: NEWSLETTERS,
+        source_url: DEFAULT_SOURCE_URL
+      });
+      return true;
+    }).reply(200, {
+      status: 'ok',
+    });
+    request(app)
+      .post('/subscribe/')
+      .set('authorization', 'Bearer TOKEN')
+      .send({ newsletters: NEWSLETTERS })
+      .expect(200, {
+        status: 'ok',
+      })
+      .end(done);
+  });
+
   it('passes through all params from body, except email', function (done) {
     var EMAIL = 'test@example.com';
     var NEWSLETTERS = 'a,b,c';


### PR DESCRIPTION
@shane-tomlinson this addresses your feedback from https://github.com/mozilla/fxa-basket-proxy/pull/56#issuecomment-382424881, and also adds an explicit test for the trailing-slash on `/subscribe/` that was mentioned in https://github.com/mozilla/fxa-content-server/issues/6076#issuecomment-382191117; r?