### PR TITLE
feat(fake-server): Have the fake server serve CORS requests, handle OAuth tokens.

### DIFF
--- a/bin/fake-basket-server.js
+++ b/bin/fake-basket-server.js
@@ -13,13 +13,13 @@ var url = require('url');
 var config = require('../lib/config');
 var logger = require('../lib/logging')('server');
 
-var app = require('../lib/basket/fake.js');
+const app = require('../lib/basket/fake');
 
 function listen(app) {
   var apiUrl = url.parse(config.get('basket.api_url'));
   app.listen(apiUrl.port, apiUrl.hostname);
-  logger.info('FxA Fake Basket Server listening on port', apiUrl.port);
+  logger.info(`FxA Fake Basket Server listening on port ${apiUrl.port}`);
   return true;
 }
 
-listen(app());
+listen(app(logger));


### PR DESCRIPTION
fixes #75

We want to retire fxa-basket-proxy and still need a way to test that basket functionality works.

Right now the basket proxy shuttles requests to the basket server, using a shared secret for authentication. Basket itself can also authenticate with OAuth tokens.

So that we can continue to test on fxa-dev boxes, fake.js serves CORS requests and accepts OAuth access tokens.

blocks mozilla/fxa-content-server#7050